### PR TITLE
Trigger submit event when pressing enter on form field

### DIFF
--- a/src/jquery.simulate.key-sequence.js
+++ b/src/jquery.simulate.key-sequence.js
@@ -333,16 +333,22 @@
 		'{enter}': function (rng, s, opts){
 			rng.insertEOL();
 			rng.select();
+
+			if (opts.triggerFormEvents === true) {
+				var $_form = $(rng._el).parents('form');
+				if ($_form.length && $_form.find('[type=submit]').length) {
+					$(rng._el).on('keydown', function (event) {
+						if (event.keyCode === 13 && !event.isDefaultPrevented()) {
+							$_form.trigger('submit');
+						}
+					});
+				}
+			}
+
 			if (opts.triggerKeyEvents === true) {
 				$(rng._el).simulate('keydown', {keyCode: 13});
 				$(rng._el).simulate('keypress', {keyCode: 13, which: 13, charCode: 13});
 				$(rng._el).simulate('keyup', {keyCode: 13});
-			}
-			if (opts.triggerFormEvents === true) {
-				var $_form = $(rng._el).parents('form');
-				if ($_form.length && $_form.find('[type=submit]').length) {
-					$_form.trigger('submit');
-				}
 			}
 		},
 		

--- a/tests/key-sequence.js
+++ b/tests/key-sequence.js
@@ -146,15 +146,43 @@ $(document).ready(function() {
 		var testForm = $('<form method="post"><input type="submit"></form>');
 		var testElement = $('#textInput').appendTo(testForm);
 		var testSequence = 'foo{enter}';
+		var submitted = false;
 
 		testForm.on('submit', function (event) {
-			ok(event.type);
-			event.preventDefault();
-			start();
+			submitted = true;
 			return false;
 		});
 
 		testElement.simulate("key-sequence", {sequence: testSequence});
+
+		setTimeout(function() {
+			strictEqual(submitted, true);
+			start();
+		}, 10);		
+	});
+
+	test("form submit with enter when keydown event is default prevented", function() {
+		stop();
+		var testForm = $('<form method="post"><input type="submit"></form>');
+		var testElement = $('#textInput').appendTo(testForm);
+		var testSequence = 'foo{enter}';
+		var submitted = false;
+
+		testElement.on('keydown', function (event) {
+			event.preventDefault();
+		});
+
+		testForm.on('submit', function (event) {
+			submitted = true;
+			return false;
+		});
+
+		testElement.simulate("key-sequence", {sequence: testSequence});
+
+		setTimeout(function() {
+			strictEqual(submitted, false);
+			start();
+		}, 10);
 	});
 	
 	test("delay", function() {


### PR DESCRIPTION
Closes #13

I realized that triggering the submit event is the way to go instead of trying to call `submit()` on the form itself. The latter would result in submitting the form but no way to catch the event, because it triggered no events.

It also takes into account when even.preventDefault() is called on the keydown event to prevent submit from happening.
