### PR TITLE
Use .focus() instead of target.focus() for quirks test

### DIFF
--- a/src/jquery.simulate.key-sequence.js
+++ b/src/jquery.simulate.key-sequence.js
@@ -127,7 +127,7 @@
 					}	
 				});
 			}
-			target.focus();
+			$target.focus();
 			if (typeof sequence === 'undefined') { // no string, so we just set up the event handlers
 				return;
 			}


### PR DESCRIPTION
I am using this plugin in node with jsdom and using the plain `target` throws an error in bililiteRange.js:

```
TypeError: Cannot call method 'replace' of null
```

It traces back to the line I have changed in the commit. I guess the issue is that pure dom elements do not automatically get a focus method with jsdom. However, using the jquery object eliminates this problem.
