### PR TITLE
Add a Null Check in windowOfDocument

### DIFF
--- a/libs/jquery.simulate.js
+++ b/libs/jquery.simulate.js
@@ -22,7 +22,7 @@ function isDocument(ele) {
 
 function windowOfDocument(doc) {
 	for (var i=0; i < window.frames.length; i+=1) {
-		if (window.frames[i].document === doc) {
+		if (window.frames[i] && window.frames[i].document === doc) {
 			return window.frames[i];
 		}
 	}


### PR DESCRIPTION
Add a null check for windowOfDocument function. It is possible you can’t access
a window.frame when it is cross-domain. This could happen at any index
in the window.frame so best to check all of them.