### PR TITLE
MouseEvent overload: Allow options to be an optional paramter

### DIFF
--- a/src/jquery.simulate.ext.js
+++ b/src/jquery.simulate.ext.js
@@ -18,6 +18,7 @@
 		rdocument = /\[object (?:HTML)?Document\]/;
 	
 	$.simulate.prototype.mouseEvent = function(type, options) {
+		options = options || {};
 		if (options.pageX || options.pageY) {
 			var doc = rdocument.test(Object.prototype.toString.call(this.target))? this.target : (this.target.ownerDocument || document);
 			options.clientX = (options.pageX || 0) - $(doc).scrollLeft();


### PR DESCRIPTION
When using this plugin without specifying options for original mouse events, ex: `$el.simulate('click');`. It currently throws an error:
```
Uncaught TypeError: Cannot read property 'pageX' of undefined
    at $.simulate.mouseEvent (http://localhost:9876/base/node_modules/jquery-simulate-ext/src/jquery.simulate.ext.js:21:14)
    at $.simulate.createEvent (http://localhost:9876/base/node_modules/jquery-simulate/jquery.simulate.js:83:16)
    at $.simulate.simulateEvent (http://localhost:9876/base/node_modules/jquery-simulate/jquery.simulate.js:73:20)
    at new $.simulate (http://localhost:9876/base/node_modules/jquery-simulate/jquery.simulate.js:32:8)
    at HTMLButtonElement.<anonymous> (http://localhost:9876/base/node_modules/jquery-simulate-ext/src/jquery.simulate.drag-n-drop.js:27:5)
    at Function.each (http://localhost:9876/base/node_modules/jquery/dist/jquery.js:374:23)
    at jQuery.fn.init.each (http://localhost:9876/base/node_modules/jquery/dist/jquery.js:139:17)
    at jQuery.fn.init.$.fn.simulate (http://localhost:9876/base/node_modules/jquery-simulate-ext/src/jquery.simulate.drag-n-drop.js:26:16)
    at Object.<anonymous> (http://localhost:9876/base/test/jasmine/index.js:141113:42)
```